### PR TITLE
fix(fillRect): use height to draw height of rect

### DIFF
--- a/lib/canvasContext.js
+++ b/lib/canvasContext.js
@@ -349,8 +349,8 @@ CanvasContext.prototype._fillRect = function CanvasContext__fillRect(fillColor, 
     var points = [
         this._transform.multiplyPoint(x, y),
         this._transform.multiplyPoint(x + width, y),
-        this._transform.multiplyPoint(x + width, y + width),
-        this._transform.multiplyPoint(x, y + width),
+        this._transform.multiplyPoint(x + width, y + height),
+        this._transform.multiplyPoint(x, y + height),
         this._transform.multiplyPoint(x, y)
     ];
 


### PR DESCRIPTION
Test scenario:
```javascript
const fs = require('fs');
const canvasRenderer = require('canvas-renderer');

const canvas = canvasRenderer.createCanvas(
  400,
  500
);

const ctx = canvas.getContext('2d');


ctx.fillStyle = '#999999';
ctx.fillRect(
  0,
  0,
  400,
  500
);

const path = `./frame.png`;
console.log('writing frame: ' + path);
const image = fs.createWriteStream(path);
image.write(canvas.toPng());
image.close();
```

https://replit.com/@BertVerhelst/RashVitalKey#index.js


before this PR, this would be the output:
<img src="https://user-images.githubusercontent.com/1710840/183307222-1ff676f9-0017-4f65-8e11-a8455030a6cb.png" width="400">


after this fix the red rectangle is correctly drawn with 400 x 500 px:
<img src="https://user-images.githubusercontent.com/1710840/183307251-7f187e4b-5c9f-4921-a247-4df50fff5dd4.png" width="400">
